### PR TITLE
Support python3 < 3.4.2

### DIFF
--- a/aioetcd/__init__.py
+++ b/aioetcd/__init__.py
@@ -41,7 +41,7 @@ class Node:
     @property
     def prev_node(self):
         if isinstance(self._prev_node, dict):
-            self._prev_node = Node(**self.prevNode)
+            self._prev_node = Node(**self._prev_node)
         return self._prev_node
 
     @asyncio.coroutine
@@ -51,6 +51,10 @@ class Node:
         content = head.content.read_nowait()
         head.close(force=True)
         return bool(content)
+
+    def __str__(self):
+        return 'key={}, value={}, expiration={}, ttl={}, raft_index={}'.format(
+            self.key, self.value, self.expiration, self.ttl, self.raft_index)
 
 
 class FileNode(Node):


### PR DESCRIPTION
This pull request slightly modifies the implementation so that Python3 versions older than 3.4.2 can use this library. The `loop.create_task` is only available in 3.4.2 and as indicated here https://docs.python.org/3/library/asyncio-eventloop.html#coroutines the way to support older versions is by using `asyncio.async`.

I was running a stand alone `etcd` instance and when running the simple_client.py the leader function would return `404 page not found`. This seems to be the case when running etcd stand alone as I get the same thing when going directly to etcd.

```
$ curl -L http://127.0.0.1:4001/v2/leader
404 page not found
```

I've added a change so that the leader function will return the leader or None.

I have also added a simple `__str__` to the Node class so that the simple_client.py script can display some meaningful information when it does `print(result)`. So now instead of seeing:

```
client_get
<aioetcd.FileNode object at 0x7f8a12879550>
```

it will show:

```
client_get
key=/hello, value=43, expiration=None, ttl=None, raft_index=6740
```
